### PR TITLE
Fixed imports for STDF tests

### DIFF
--- a/Semi_ATE/data/STDF/ATR.py
+++ b/Semi_ATE/data/STDF/ATR.py
@@ -1,4 +1,4 @@
-from STDF import STDR
+from . import STDR
 
 class ATR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/BPS.py
+++ b/Semi_ATE/data/STDF/BPS.py
@@ -1,4 +1,4 @@
-from STDF import STDR
+from . import STDR
 
 class BPS(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/DTR.py
+++ b/Semi_ATE/data/STDF/DTR.py
@@ -1,4 +1,4 @@
-from STDF import STDR
+from . import STDR
 
 class DTR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/EPS.py
+++ b/Semi_ATE/data/STDF/EPS.py
@@ -1,5 +1,4 @@
-from STDF import STDR
-
+from . import STDR
 
 class EPS(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/FAR.py
+++ b/Semi_ATE/data/STDF/FAR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class FAR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/FTR.py
+++ b/Semi_ATE/data/STDF/FTR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class FTR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/GDR.py
+++ b/Semi_ATE/data/STDF/GDR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class GDR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/HBR.py
+++ b/Semi_ATE/data/STDF/HBR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class HBR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/MIR.py
+++ b/Semi_ATE/data/STDF/MIR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class MIR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/MPR.py
+++ b/Semi_ATE/data/STDF/MPR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class MPR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/MRR.py
+++ b/Semi_ATE/data/STDF/MRR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class MRR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/PCR.py
+++ b/Semi_ATE/data/STDF/PCR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class PCR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/PGR.py
+++ b/Semi_ATE/data/STDF/PGR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class PGR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/PIR.py
+++ b/Semi_ATE/data/STDF/PIR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class PIR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/PLR.py
+++ b/Semi_ATE/data/STDF/PLR.py
@@ -1,6 +1,5 @@
 import sys
-from STDF import STDR
-
+from . import STDR
 
 class PLR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/PMR.py
+++ b/Semi_ATE/data/STDF/PMR.py
@@ -1,6 +1,5 @@
 import sys
-from STDF import STDR
-
+from . import STDR
 
 class PMR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/PRR.py
+++ b/Semi_ATE/data/STDF/PRR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 
 class PRR(STDR):

--- a/Semi_ATE/data/STDF/PTR.py
+++ b/Semi_ATE/data/STDF/PTR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class PTR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/RDR.py
+++ b/Semi_ATE/data/STDF/RDR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class RDR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/SBR.py
+++ b/Semi_ATE/data/STDF/SBR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class SBR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/SDR.py
+++ b/Semi_ATE/data/STDF/SDR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class SDR(STDR):
     def __init__(self, version=None, endian=None, record = None):

--- a/Semi_ATE/data/STDF/TSR.py
+++ b/Semi_ATE/data/STDF/TSR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 
 class TSR(STDR):

--- a/Semi_ATE/data/STDF/WCR.py
+++ b/Semi_ATE/data/STDF/WCR.py
@@ -1,5 +1,5 @@
 import sys
-from STDF import STDR
+from . import STDR
 
 class WCR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/WIR.py
+++ b/Semi_ATE/data/STDF/WIR.py
@@ -1,7 +1,7 @@
 import sys
 import time
 
-from STDF import STDR
+from . import STDR
 
 class WIR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/WRR.py
+++ b/Semi_ATE/data/STDF/WRR.py
@@ -1,8 +1,7 @@
 import sys
 import time
 
-from STDF import STDR
-
+from . import STDR
 
 class WRR(STDR):
     def __init__(self, version=None, endian=None, record=None):

--- a/Semi_ATE/data/STDF/__init__.py
+++ b/Semi_ATE/data/STDF/__init__.py
@@ -26,7 +26,6 @@ from .TSR import *
 from .WCR import *
 from .WIR import *
 from .WRR import *
-from .utils import create_record_object, records_from_file
 
 
 __version__ = '0.0'

--- a/Semi_ATE/data/STDF/utils.py
+++ b/Semi_ATE/data/STDF/utils.py
@@ -9,9 +9,9 @@ import struct
 import sys
 import io
 
-from STDF import ts_to_id
-from STDF import supported
-from STDF import (ATR, BPS, DTR, EPS, FAR, FTR, GDR, HBR, MIR, MPR, MRR, PCR, PGR, PIR, PLR, PMR, PRR, PTR, RDR, SBR, SDR, TSR, WIR, WCR, WRR)
+from .STDR import ts_to_id
+from . import supported
+from . import (ATR, BPS, DTR, EPS, FAR, FTR, GDR, HBR, MIR, MPR, MRR, PCR, PGR, PIR, PLR, PMR, PRR, PTR, RDR, SBR, SDR, TSR, WIR, WCR, WRR)
 
 #from ATE.utils.compression import default_compression
 #from ATE.utils.compression import get_deflated_file_size

--- a/tests/STDF/test_ATR.py
+++ b/tests/STDF/test_ATR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import ATR
+from Semi_ATE.data.STDF import ATR
 
 #   Audit Trail Record
 #   Function:

--- a/tests/STDF/test_BPS.py
+++ b/tests/STDF/test_BPS.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import BPS
+from Semi_ATE.data.STDF import BPS
 
 #   Begin Program Section Record
 #   Function:

--- a/tests/STDF/test_DTR.py
+++ b/tests/STDF/test_DTR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import DTR
+from Semi_ATE.data.STDF import DTR
 
 #   Datalog Text Record
 #   Function:

--- a/tests/STDF/test_EPS.py
+++ b/tests/STDF/test_EPS.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import EPS
+from Semi_ATE.data.STDF import EPS
 
 #   End Program Section Record
 #   Function:

--- a/tests/STDF/test_FAR.py
+++ b/tests/STDF/test_FAR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import FAR
+from Semi_ATE.data.STDF import FAR
 
 #   File Attributes Record
 #   Functuion:

--- a/tests/STDF/test_FTR.py
+++ b/tests/STDF/test_FTR.py
@@ -2,7 +2,7 @@ import os
 import math
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import FTR
+from Semi_ATE.data.STDF import FTR
 
 #   Functional Test Record
 #   Function:

--- a/tests/STDF/test_GDR.py
+++ b/tests/STDF/test_GDR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import GDR
+from Semi_ATE.data.STDF import GDR
 
 #   Generic Data Record
 #   Function:

--- a/tests/STDF/test_HBR.py
+++ b/tests/STDF/test_HBR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import HBR
+from Semi_ATE.data.STDF import HBR
 
 #   Hardware Bin Record
 #   Function:

--- a/tests/STDF/test_MIR.py
+++ b/tests/STDF/test_MIR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import MIR
+from Semi_ATE.data.STDF import MIR
 
 #   Master Information Record
 #   Function:

--- a/tests/STDF/test_MPR.py
+++ b/tests/STDF/test_MPR.py
@@ -2,7 +2,7 @@ import os
 import math
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import MPR
+from Semi_ATE.data.STDF import MPR
 
 
 #   Multiple-Result Parametric Record

--- a/tests/STDF/test_MRR.py
+++ b/tests/STDF/test_MRR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import MRR
+from Semi_ATE.data.STDF import MRR
 
 #   Master Results Record
 #   Function:

--- a/tests/STDF/test_PCR.py
+++ b/tests/STDF/test_PCR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF.PCR import PCR
+from Semi_ATE.data.STDF import PCR
 
 #   Part Count Record
 #   Function:

--- a/tests/STDF/test_PGR.py
+++ b/tests/STDF/test_PGR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import PGR
+from Semi_ATE.data.STDF import PGR
 
 #   Pin Group Record
 #   Function:

--- a/tests/STDF/test_PIR.py
+++ b/tests/STDF/test_PIR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import PIR
+from Semi_ATE.data.STDF import PIR
 
 #   Part Information Record :
 #   Function:

--- a/tests/STDF/test_PLR.py
+++ b/tests/STDF/test_PLR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import PLR
+from Semi_ATE.data.STDF import PLR
 
 #   Pin List Record
 #   Function:

--- a/tests/STDF/test_PMR.py
+++ b/tests/STDF/test_PMR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import PMR
+from Semi_ATE.data.STDF import PMR
 
 #   Pin Map Record
 #   Function:

--- a/tests/STDF/test_PRR.py
+++ b/tests/STDF/test_PRR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import PRR
+from Semi_ATE.data.STDF import PRR
 
 #   Part Results Record
 #   Function:

--- a/tests/STDF/test_PTR.py
+++ b/tests/STDF/test_PTR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import PTR
+from Semi_ATE.data.STDF import PTR
 
 #   Parametric Test Record
 #   Function:

--- a/tests/STDF/test_RDR.py
+++ b/tests/STDF/test_RDR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import RDR
+from Semi_ATE.data.STDF import RDR
 
 #   Retest Data Record
 #   Function:

--- a/tests/STDF/test_SBR.py
+++ b/tests/STDF/test_SBR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import SBR
+from Semi_ATE.data.STDF import SBR
 
 #   Software Bin Record
 #   Function:

--- a/tests/STDF/test_SDR.py
+++ b/tests/STDF/test_SDR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import SDR
+from Semi_ATE.data.STDF import SDR
 
 #   Site Description Record
 #   Function:

--- a/tests/STDF/test_STDR.py
+++ b/tests/STDF/test_STDR.py
@@ -1,4 +1,4 @@
-from STDF import STDR
+from Semi_ATE.data.STDF import STDR
         
 
 def test_STDR():

--- a/tests/STDF/test_TSR.py
+++ b/tests/STDF/test_TSR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import TSR
+from Semi_ATE.data.STDF import TSR
 
 #   Test Synopsis Record
 #   Function:

--- a/tests/STDF/test_WCR.py
+++ b/tests/STDF/test_WCR.py
@@ -3,7 +3,7 @@ import tempfile
 import pytest
 
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import WCR
+from Semi_ATE.data.STDF import WCR
 
 #   Wafer Results Record
 #   Function:

--- a/tests/STDF/test_WIR.py
+++ b/tests/STDF/test_WIR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import WIR
+from Semi_ATE.data.STDF import WIR
 
 #   Wafer Information Record
 #   Function:

--- a/tests/STDF/test_WRR.py
+++ b/tests/STDF/test_WRR.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from tests.STDF.STDFRecordTest import STDFRecordTest
-from STDF import WRR
+from Semi_ATE.data.STDF import WRR
 
 #   Wafer Results Record
 #   Function:


### PR DESCRIPTION
The following fix for import was applied for all STDF classes and STDF tests classes :
- for STDF classes : from . import STDR
- for STDF test classes : from Semi_ATE.data.STDF import STDF_CLASS_NAME