### PR TITLE
Fixed ATDF timstamp generation for Windows OS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  - test-linux:
+  test-linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include *.md
 include LICENSE
+recursive-include Semi_ATE *.md
 recursive-include requirements *.txt
 recursive-exclude tests *.py
 recursive-include Semi_ATE *.py

--- a/Semi_ATE/data/STDF/STDR.py
+++ b/Semi_ATE/data/STDF/STDR.py
@@ -2033,7 +2033,15 @@ class STDR(ABC):
                     else:
     #                    ATDF spec page 9:
     #                    Insignificant leading zeroes in all numbers are optional.
-                        t = time.strftime("%-H:%-M:%-S %-d-%b-%Y", time.gmtime(timestamp))
+                        t = ""
+                        if os.name == "nt":
+                            t = time.strftime(
+                                "%#H:%#M:%#S %#d-%b-%Y", time.gmtime(timestamp)
+                            )
+                        else:
+                            t = time.strftime(
+                                "%-H:%-M:%-S %-d-%b-%Y", time.gmtime(timestamp)
+                            )
                         body += '%s|' % (t.upper())
                         
                 elif sequence[field] in skip_fields:

--- a/Semi_ATE/data/STDF/WIR.py
+++ b/Semi_ATE/data/STDF/WIR.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import time
 
 from . import STDR
@@ -59,7 +60,11 @@ Location:
 #       5 START_T
         v = self.get_fields(5)[3]
         if v != None:
-            t = time.strftime("%-H:%-M:%-S %-d-%b-%Y", time.gmtime(v))
+            t = ""
+            if os.name == "nt":
+                t = time.strftime("%#H:%#M:%#S %#d-%b-%Y", time.gmtime(v))
+            else:
+                t = time.strftime("%-H:%-M:%-S %-d-%b-%Y", time.gmtime(v))
             body += "%s|" % (t.upper())
 
 #       4 SITE_GRP

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     version=__version__,
     description="Library to parse/write STDF/ATEF files",
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     author="Semi-ATE",
     author_email="info@Semi-ATE.com",
     license="MIT",


### PR DESCRIPTION
## Description of Changes
Changes are made to support ATDF under Windows OS.
The Python time.strftime is platform dependent and code for removing leading zeros for both Unix/Windows OS was added.